### PR TITLE
Fallback byte array decoding using base64 standard encoding

### DIFF
--- a/runtime/query.go
+++ b/runtime/query.go
@@ -236,7 +236,10 @@ func parseField(fieldDescriptor protoreflect.FieldDescriptor, value string) (pro
 	case protoreflect.BytesKind:
 		v, err := base64.URLEncoding.DecodeString(value)
 		if err != nil {
-			return protoreflect.Value{}, err
+			v, err = base64.StdEncoding.DecodeString(value)
+			if err != nil {
+				return protoreflect.Value{}, err
+			}
 		}
 		return protoreflect.ValueOfBytes(v), nil
 	case protoreflect.MessageKind, protoreflect.GroupKind:

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -236,6 +236,8 @@ func parseField(fieldDescriptor protoreflect.FieldDescriptor, value string) (pro
 	case protoreflect.BytesKind:
 		v, err := base64.URLEncoding.DecodeString(value)
 		if err != nil {
+			// From the start Prysm's v1alpha1 endpoints made use of passing NOT URL-encoded base64 values in the URL.
+			// For backward compatibility we can't assume byte arrays are URL-encoded.
 			v, err = base64.StdEncoding.DecodeString(value)
 			if err != nil {
 				return protoreflect.Value{}, err


### PR DESCRIPTION
Updating the gateway to v2 in Prysm resulted in failed v1alpha1 API requests. For backwards compatibility we can't assume byte arrays are URL-encoded.